### PR TITLE
FIX: Correctly Capture Invalid JSON 

### DIFF
--- a/src/Manticoresearch/Response.php
+++ b/src/Manticoresearch/Response.php
@@ -61,11 +61,12 @@ class Response
     public function getResponse()
     {
         if (null === $this->_response) {
-            try {
-                $this->_response = json_decode($this->_string, true);
-            } catch (\Exception $e) {
+            $this->_response = json_decode($this->_string, true);
+
+            if (json_last_error() !== JSON_ERROR_NONE) {
                 throw new RuntimeException('fatal error while trying to decode JSON response');
             }
+
             if (empty($this->_response)) {
                 $this->_response = [];
             }


### PR DESCRIPTION
hi,

I've been caught out by this before, but json_decode function does not throw an exception. This PR fixes this

Cheers

Gordon