### PR TITLE
FIX: Set Endpoint Producing Invalid SQL

### DIFF
--- a/src/Manticoresearch/Endpoints/Nodes/Set.php
+++ b/src/Manticoresearch/Endpoints/Nodes/Set.php
@@ -18,8 +18,8 @@ class Set extends EmulateBySql
         $this->_body = $params;
         if (isset($params['variable']) && is_array($params['variable'])) {
             return parent::setBody([
-                'query' => "SET " . (isset($params['type']) ?  $params['type'] . "'" : "")." ".
-                    $params['variable']['name']." '" . $params['variable']['value']
+                'query' =>  "SET " . (isset($params['type']) ?  $params['type'] . "'" : "")." ".
+                    $params['variable']['name']."=" . $params['variable']['value']
             ]);
 
         }


### PR DESCRIPTION
Unit testing with trying to set PROFILING to a value of 0, the SQL generated was
```
set PROFILING '0
```
The following appears to work, and this is the effect of the change:
```
set PROFILING=0
```
