### PR TITLE
Unit Test for Query.php and a Fix

### DIFF
--- a/src/Manticoresearch/Query.php
+++ b/src/Manticoresearch/Query.php
@@ -5,7 +5,7 @@ namespace Manticoresearch;
 
 class Query implements Arrayable
 {
-    protected $_params;
+    protected $_params = [];
 
     public function add($k, $v)
     {

--- a/test/Manticoresearch/QueryTest.php
+++ b/test/Manticoresearch/QueryTest.php
@@ -1,0 +1,77 @@
+<?php
+
+
+namespace Manticoresearch\Test;
+
+
+use Manticoresearch\Client;
+use Manticoresearch\Connection\Strategy\Random;
+use Manticoresearch\Connection\Strategy\RoundRobin;
+use Manticoresearch\Exceptions\ConnectionException;
+use Manticoresearch\Query;
+use Manticoresearch\Request;
+use PHPUnit\Framework\TestCase;
+
+class QueryTest extends TestCase
+{
+    /** @var Query */
+    private $query;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->query = new Query();
+    }
+
+    public function testNoParams()
+    {
+        $this->assertEquals([], $this->query->toArray());
+    }
+
+    public function testParamsNoNesting()
+    {
+        $this->query->add('a', 1);
+        $this->query->add('b', 2);
+        $this->query->add('c', 3);
+        $this->assertEquals([
+            'a' => 1,
+            'b' => 2,
+            'c' =>3,
+        ], $this->query->toArray());
+    }
+
+    public function testParamsWithNesting()
+    {
+        $this->query->add('a', 1);
+        $subParams = ['b' => 2, 'c' => 3];
+        $this->query->add('x', $subParams);
+        $this->assertEquals([
+            'a' => 1,
+            'x' => [
+                'b' => 2,
+                'c' =>3,
+            ]
+        ], $this->query->toArray());
+    }
+
+    public function testParamsWithNull()
+    {
+        $this->query->add('a', 1);
+        $subParams = ['b' => null];
+        $this->query->add('x', $subParams);
+        $this->assertEquals([
+            'a' => 1,
+            'x' => null
+        ], $this->query->toArray());
+    }
+
+    public function testWithParamsAndSubQuery()
+    {
+        $this->query->add('a', 1);
+        $subquery = new Query();
+        $subquery->add('b', 2);
+        $this->query->add('x', $subquery);
+        $this->assertEquals(['a' => 1, 'x' => ['b' => 2]], $this->query->toArray());
+    }
+
+}


### PR DESCRIPTION
hi,

100% unit test coverage for Query.php, and a fix for the empty case. Setting the initially array to [] instead of null fixes it

Cheers

Gordon