### PR TITLE
Improved Coverage of Client Test

### DIFF
--- a/test/Manticoresearch/ClientTest.php
+++ b/test/Manticoresearch/ClientTest.php
@@ -5,6 +5,7 @@ namespace Manticoresearch\Test;
 
 
 use Manticoresearch\Client;
+use Manticoresearch\Connection;
 use Manticoresearch\Connection\Strategy\Random;
 use Manticoresearch\Exceptions\ConnectionException;
 use Manticoresearch\Test\Helper\PopulateHelperTest;
@@ -15,6 +16,20 @@ class ClientTest extends TestCase
     public function testEmptyConfig()
     {
         $client = new Client();
+        $this->assertCount(1, $client->getConnections());
+    }
+
+    public function testCluster()
+    {
+        $client = new Client();
+        $this->assertInstanceOf('Manticoresearch\Cluster', $client->cluster());
+    }
+
+    public function testCreationWithConnection()
+    {
+        $params = ['host' => $_SERVER['MS_HOST'], 'port' => $_SERVER['MS_PORT']];
+        $connection = new Connection($params);
+        $client = new Client($connection);
         $this->assertCount(1, $client->getConnections());
     }
 

--- a/test/Manticoresearch/ClientTest.php
+++ b/test/Manticoresearch/ClientTest.php
@@ -19,6 +19,18 @@ class ClientTest extends TestCase
         $this->assertCount(1, $client->getConnections());
     }
 
+    public function testObjectStrategy()
+    {
+        $client = new Client(["connectionStrategy"  => new Connection\Strategy\RoundRobin()]);
+        $this->assertCount(1, $client->getConnections());
+    }
+
+    public function testClassnameStrategy()
+    {
+        $client = new Client(["connectionStrategy"  => 'Connection\Strategy\RoundRobin']);
+        $this->assertCount(1, $client->getConnections());
+    }
+
     public function testCluster()
     {
         $client = new Client();
@@ -29,7 +41,17 @@ class ClientTest extends TestCase
     {
         $params = ['host' => $_SERVER['MS_HOST'], 'port' => $_SERVER['MS_PORT']];
         $connection = new Connection($params);
-        $client = new Client($connection);
+        $params = ['connections' => $connection];
+        $client = new Client($params);
+        $this->assertCount(1, $client->getConnections());
+    }
+
+    public function testCreationWithConnectionSingularArray()
+    {
+        $params = ['host' => $_SERVER['MS_HOST'], 'port' => $_SERVER['MS_PORT']];
+        $connection = new Connection($params);
+        $params = ['connections' => [$connection]];
+        $client = new Client($params);
         $this->assertCount(1, $client->getConnections());
     }
 


### PR DESCRIPTION
I am not sure how best to test the sql() method, but this deals with initializing connections with different strategies in order to achieve code coverage > 90 % for `ClientTest.php`