### PR TITLE
FIX: Erroneous $ prefixing a variable name as a JSON parameter

### DIFF
--- a/src/Manticoresearch/Index.php
+++ b/src/Manticoresearch/Index.php
@@ -274,7 +274,7 @@ class Index
         $params = [
             'index' => $this->_index,
             'body' => [
-                '$query' => $query,
+                'query' => $query,
                 'options' => $options
             ]
         ];


### PR DESCRIPTION
Minor error but this breaks $index->suggest() method