### PR TITLE
Dockerized Testing Suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - docker pull manticoresearch/manticore
   - docker network create manticore
   - docker run --rm --publish 9308:9308 --network manticore --name=manticoresearch-manticore --detach manticoresearch/manticore
-  - sudo apt update && sudo apt install php-json
+  - sudo apt update && sudo apt install php-json zip unzip git
 env:
   global:
     - MS_HOST=127.0.0.1
@@ -30,6 +30,8 @@ before_script:
   - composer validate
 
 install:
+  # See https://www.digitalocean.com/community/tutorials/how-to-remove-docker-images-containers-and-volumes
+  - composer global require hirak/prestissimo
   - composer install --prefer-dist
 
 script:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '2'
+services:
+ phpcli:
+   build:
+     context: docker/phpcli
+   working_dir: /var/www
+   environment:
+     - MS_HOST=manticoresearch-manticore
+     - MS_PORT=9308
+   volumes:
+    - .:/var/www
+
+
+ manticoresearch-manticore:
+   image: manticoresearch/manticore
+   expose:
+    - 9306
+    - 9312
+

--- a/docker/phpcli/Dockerfile
+++ b/docker/phpcli/Dockerfile
@@ -2,7 +2,7 @@ FROM php:7.4-cli-buster
 
 RUN apt -y update && apt -y upgrade
 RUN apt -y install figlet git zip unzip
-RUN apt-get autoremove && sudo apt-get clean
+RUN apt-get -y autoremove && apt-get -y clean
 
 # alter bash prompt
 ENV PS1A="\u@manticore.test:\w> "

--- a/docker/phpcli/Dockerfile
+++ b/docker/phpcli/Dockerfile
@@ -1,0 +1,19 @@
+FROM php:7.1-cli-stretch
+
+RUN apt -y update && apt -y upgrade
+RUN apt -y install figlet git zip unzip
+RUN apt -y autoremove
+
+# alter bash prompt
+ENV PS1A="\u@manticore.test:\w> "
+RUN echo 'PS1=$PS1A' >> ~/.bashrc
+
+# intro message when attaching to shell
+RUN echo 'figlet -w 120 manticore unit testing' >> ~/.bashrc
+
+# install composer - see https://medium.com/@c.harrison/speedy-composer-installs-in-docker-builds-41eea6d0172b
+RUN curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer && \
+    composer global require hirak/prestissimo --no-plugins --no-scripts
+
+# Prevent the container from exiting
+CMD tail -f /dev/null

--- a/docker/phpcli/Dockerfile
+++ b/docker/phpcli/Dockerfile
@@ -1,8 +1,8 @@
-FROM php:7.1-cli-stretch
+FROM php:7.4-cli-buster
 
 RUN apt -y update && apt -y upgrade
 RUN apt -y install figlet git zip unzip
-RUN apt -y autoremove
+RUN apt-get autoremove && sudo apt-get clean
 
 # alter bash prompt
 ENV PS1A="\u@manticore.test:\w> "

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,51 @@
+Testing
+-----
+Testing is carried out using Docker and Docker Compose in order to guarantee a consistent testing environment.
+
+The following documentation assumes that you are using a shell that currently has a working directory in the root of
+the project.
+
+Create Containers
+======
+```bash
+sudo docker-compose exec phpcli /bin/bash
+```
+This may take a few minutes depending on your internet connection.
+
+Attach to Command Line Interface
+======
+The following will get you a shell on PHP command line container.
+```bash
+sudo docker-compose exec phpcli /bin/bash
+```
+
+Running PHPUnit
+======
+Simply run PHPUnit
+
+```bash
+vendor/bin/phpunit
+```
+
+Generating Local Code Coverage
+======
+```bash
+phpdbg -qrr vendor/bin/phpunit --coverage-html report test
+```
+A succesful test run will look like this:
+```bash
+root@807c5bdfe018:/var/www# phpdbg -qrr vendor/bin/phpunit --coverage-html report test
+PHPUnit 7.5.20 by Sebastian Bergmann and contributors.
+
+...............................................................  63 / 166 ( 37%)
+................S...S..........S............................... 126 / 166 ( 75%)
+..................................S.....                        166 / 166 (100%)
+
+Time: 29.28 seconds, Memory: 16.00 MB
+
+OK, but incomplete, skipped, or risky tests!
+Tests: 166, Assertions: 260, Skipped: 4.
+
+Generating code coverage report in HTML format ... done
+
+```


### PR DESCRIPTION
hi,

This PR provides instructions on how to run the unit tests for the PHP client inside a docker compose setup, meaning a consistent environment with minimal hassle to set up.  I have also shaved 17 secs off the Travis build time by simply install the package `hirak/prestissimo` globally - it allows for parallel composer downloads.

Cheers

Gordon