### PR TITLE
Fixes for PHP HTTP Transport

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
   - composer install --prefer-dist
 
 script:
-  - if [[ $TRANSPORT ]]; then composer require guzzlehttp/psr7 && composer require && php-http/curl-client && php-http/httplug && composer require ext-curl  ; fi
+  - if [[ $TRANSPORT ]]; then composer require guzzlehttp/psr7 && composer require php-http/curl-client && php-http/httplug && composer require ext-curl  ; fi
   - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit -d memory_limit=4G  test/; fi
   - if [[ $PHPUNIT_COVERAGE_TEST ]]; then phpdbg -qrr vendor/bin/phpunit -d memory_limit=4G --coverage-clover=coverage.xml   test/   ; fi
   - if [[ $PHPCS_TEST ]]; then vendor/bin/phpcs --config-set ignore_errors_on_exit 1 && vendor/bin/phpcs --config-set ignore_warnings_on_exit 1 && vendor/bin/phpcs src/ test/ ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ matrix:
     - php: 7.4
       env: PHPUNIT_TEST=1
 
+    # Test with alternative transport
+    - php: 7.4
+      env: PHPUNIT_TEST=1 TRANSPORT=PhpHttp
+
 services:
   -  docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
   - composer install --prefer-dist
 
 script:
-  - if [[ $TRANSPORT ]]; then composer require guzzlehttp/psr7 && composer require php-http/discovery && composer require http-interop/http-factory-guzzle && composer require php-http/curl-client && composer require php-http/httplug && composer require ext-curl  ; fi
+  - if [[ $TRANSPORT ]]; then composer require guzzlehttp/psr7 && composer require php-http/discovery && composer require http-interop/http-factory-guzzle && composer require php-http/curl-client  ; fi
   - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit -d memory_limit=4G  test/; fi
   - if [[ $PHPUNIT_COVERAGE_TEST ]]; then phpdbg -qrr vendor/bin/phpunit -d memory_limit=4G --coverage-clover=coverage.xml   test/   ; fi
   - if [[ $PHPCS_TEST ]]; then vendor/bin/phpcs --config-set ignore_errors_on_exit 1 && vendor/bin/phpcs --config-set ignore_warnings_on_exit 1 && vendor/bin/phpcs src/ test/ ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ install:
   - composer install --prefer-dist
 
 script:
+  - if [[ $TRANSPORT ]]; then composer require guzzlehttp/psr7 && composer require && php-http/curl-client && php-http/httplug && composer require ext-curl  ; fi
   - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit -d memory_limit=4G  test/; fi
   - if [[ $PHPUNIT_COVERAGE_TEST ]]; then phpdbg -qrr vendor/bin/phpunit -d memory_limit=4G --coverage-clover=coverage.xml   test/   ; fi
   - if [[ $PHPCS_TEST ]]; then vendor/bin/phpcs --config-set ignore_errors_on_exit 1 && vendor/bin/phpcs --config-set ignore_warnings_on_exit 1 && vendor/bin/phpcs src/ test/ ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
   - composer install --prefer-dist
 
 script:
-  - if [[ $TRANSPORT ]]; then composer require guzzlehttp/psr7 && composer require php-http/curl-client && php-http/httplug && composer require ext-curl  ; fi
+  - if [[ $TRANSPORT ]]; then composer require guzzlehttp/psr7 && composer require php-http/discovery && composer require php-http/curl-client && php-http/httplug && composer require ext-curl  ; fi
   - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit -d memory_limit=4G  test/; fi
   - if [[ $PHPUNIT_COVERAGE_TEST ]]; then phpdbg -qrr vendor/bin/phpunit -d memory_limit=4G --coverage-clover=coverage.xml   test/   ; fi
   - if [[ $PHPCS_TEST ]]; then vendor/bin/phpcs --config-set ignore_errors_on_exit 1 && vendor/bin/phpcs --config-set ignore_warnings_on_exit 1 && vendor/bin/phpcs src/ test/ ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
   - composer install --prefer-dist
 
 script:
-  - if [[ $TRANSPORT ]]; then composer require guzzlehttp/psr7 && composer require php-http/discovery && composer require php-http/curl-client && php-http/httplug && composer require ext-curl  ; fi
+  - if [[ $TRANSPORT ]]; then composer require guzzlehttp/psr7 && composer require php-http/discovery && composer require http-interop/http-factory-guzzle && composer require php-http/curl-client && php-http/httplug && composer require ext-curl  ; fi
   - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit -d memory_limit=4G  test/; fi
   - if [[ $PHPUNIT_COVERAGE_TEST ]]; then phpdbg -qrr vendor/bin/phpunit -d memory_limit=4G --coverage-clover=coverage.xml   test/   ; fi
   - if [[ $PHPCS_TEST ]]; then vendor/bin/phpcs --config-set ignore_errors_on_exit 1 && vendor/bin/phpcs --config-set ignore_warnings_on_exit 1 && vendor/bin/phpcs src/ test/ ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
   - composer install --prefer-dist
 
 script:
-  - if [[ $TRANSPORT ]]; then composer require guzzlehttp/psr7 && composer require php-http/discovery && composer require http-interop/http-factory-guzzle && composer require php-http/curl-client && php-http/httplug && composer require ext-curl  ; fi
+  - if [[ $TRANSPORT ]]; then composer require guzzlehttp/psr7 && composer require php-http/discovery && composer require http-interop/http-factory-guzzle && composer require php-http/curl-client && composer require php-http/httplug && composer require ext-curl  ; fi
   - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit -d memory_limit=4G  test/; fi
   - if [[ $PHPUNIT_COVERAGE_TEST ]]; then phpdbg -qrr vendor/bin/phpunit -d memory_limit=4G --coverage-clover=coverage.xml   test/   ; fi
   - if [[ $PHPCS_TEST ]]; then vendor/bin/phpcs --config-set ignore_errors_on_exit 1 && vendor/bin/phpcs --config-set ignore_warnings_on_exit 1 && vendor/bin/phpcs src/ test/ ; fi

--- a/src/Manticoresearch/Transport/PhpHttp.php
+++ b/src/Manticoresearch/Transport/PhpHttp.php
@@ -52,7 +52,7 @@ class PhpHttp extends Transport implements TransportInterface
         $method = $request->getMethod();
 
         $headers = $connection->getHeaders();
-        $headers[] = sprintf('Content-Type: %s', $request->getContentType());
+        $headers['Content-Type'] = $request->getContentType();
         $data = $request->getBody();
         if (!empty($data)) {
             if (is_array($data)) {

--- a/test/Manticoresearch/ClientTest.php
+++ b/test/Manticoresearch/ClientTest.php
@@ -89,7 +89,8 @@ class ClientTest extends TestCase
                     'curl' => [
                         CURLOPT_FAILONERROR => true
                     ],
-                    'persistent' => true
+                    'persistent' => true,
+                    'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
                 ],
                 [
                     'host' => '123.0.0.2',
@@ -101,7 +102,8 @@ class ClientTest extends TestCase
                         CURLOPT_SSL_VERIFYPEER => true
                     ],
                     'connection_timeout' => 1,
-                    'persistent' => true
+                    'persistent' => true,
+                    'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
                 ],
 
             ]

--- a/test/Manticoresearch/Connection/Strategy/RandomTest.php
+++ b/test/Manticoresearch/Connection/Strategy/RandomTest.php
@@ -17,11 +17,13 @@ class RandomTest extends TestCase
         $client->setHosts([
             [
                 'host' => $_SERVER['MS_HOST'],
-                'port' => (int)($_SERVER['MS_PORT'])
+                'port' => (int)($_SERVER['MS_PORT']),
+                'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
             ],
             [
                 'host' => $_SERVER['MS_HOST'],
-                'port' => 9309
+                'port' => 9309,
+                'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
             ],
 
         ]);

--- a/test/Manticoresearch/Connection/Strategy/RoundRobinTest.php
+++ b/test/Manticoresearch/Connection/Strategy/RoundRobinTest.php
@@ -14,11 +14,13 @@ class RoundRobinTest extends TestCase
         $client->setHosts([
             [
                 'host' => $_SERVER['MS_HOST'],
-                'port' => $_SERVER['MS_PORT']
+                'port' => $_SERVER['MS_PORT'],
+                'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
             ],
             [
                 'host' => $_SERVER['MS_HOST'],
-                'port' => 9309
+                'port' => 9309,
+                'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
             ],
 
         ]);

--- a/test/Manticoresearch/Connection/Strategy/StaticRoundRobinTest.php
+++ b/test/Manticoresearch/Connection/Strategy/StaticRoundRobinTest.php
@@ -14,11 +14,13 @@ class StaticRoundRobinTest extends TestCase
         $client->setHosts([
             [
                 'host' => $_SERVER['MS_HOST'],
-                'port' => $_SERVER['MS_PORT']
+                'port' => $_SERVER['MS_PORT'],
+                'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
             ],
             [
                 'host' => $_SERVER['MS_HOST'],
-                'port' => $_SERVER['MS_PORT']
+                'port' => $_SERVER['MS_PORT'],
+                'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
             ],
 
         ]);

--- a/test/Manticoresearch/ConnectionTest.php
+++ b/test/Manticoresearch/ConnectionTest.php
@@ -43,8 +43,8 @@ class ConnectionTest extends TestCase
 
     public function testSetTransportGetTransport()
     {
-        $this->connection->setTransport('http');
-        $this->assertEquals('http', $this->connection->getTransport());
+        $this->connection->setTransport('Http');
+        $this->assertEquals('Http', $this->connection->getTransport());
     }
 
     public function testSetHeadersGetHeaders()

--- a/test/Manticoresearch/Endpoints/BulkTest.php
+++ b/test/Manticoresearch/Endpoints/BulkTest.php
@@ -9,7 +9,11 @@ class BulkTest extends \PHPUnit\Framework\TestCase
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
-        $params = ['host' => $_SERVER['MS_HOST'], 'port' => $_SERVER['MS_PORT']];
+        $params = [
+            'host' => $_SERVER['MS_HOST'],
+            'port' => $_SERVER['MS_PORT'],
+            'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
+        ];
         static::$client = new Client($params);
         $params = [
             'index' => 'bulktest',

--- a/test/Manticoresearch/Endpoints/HelpersTest.php
+++ b/test/Manticoresearch/Endpoints/HelpersTest.php
@@ -8,7 +8,11 @@ class HelpersTest  extends \PHPUnit\Framework\TestCase
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
-        $params = ['host' => $_SERVER['MS_HOST'], 'port' => $_SERVER['MS_PORT']];
+        $params = [
+            'host' => $_SERVER['MS_HOST'],
+            'port' => $_SERVER['MS_PORT'],
+            'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
+        ];
         static::$client = new Client($params);
         $params = [
             'index' => 'products',

--- a/test/Manticoresearch/Endpoints/Indices/CreateTest.php
+++ b/test/Manticoresearch/Endpoints/Indices/CreateTest.php
@@ -10,7 +10,11 @@ class CreateTest  extends \PHPUnit\Framework\TestCase
 {
     public function testCreateTableWithOptions()
     {
-        $params = ['host' => $_SERVER['MS_HOST'], 'port' => $_SERVER['MS_PORT']];
+        $params = [
+            'host' => $_SERVER['MS_HOST'],
+            'port' => $_SERVER['MS_PORT'],
+            'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
+        ];
         $client = new Client($params);
         $params = [
             'index' => 'products',
@@ -42,7 +46,11 @@ class CreateTest  extends \PHPUnit\Framework\TestCase
 
     public function testCreateDistributed()
     {
-        $params = ['host' => $_SERVER['MS_HOST'], 'port' => $_SERVER['MS_PORT']];
+        $params = [
+            'host' => $_SERVER['MS_HOST'],
+            'port' => $_SERVER['MS_PORT'],
+            'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
+        ];
         $client = new Client($params);
         $params = [
             'index' => 'testrt',
@@ -78,7 +86,11 @@ class CreateTest  extends \PHPUnit\Framework\TestCase
 
     public function testNoIndexDrop()
     {
-        $params = ['host' => $_SERVER['MS_HOST'], 'port' => $_SERVER['MS_PORT']];
+        $params = [
+            'host' => $_SERVER['MS_HOST'],
+            'port' => $_SERVER['MS_PORT'],
+            'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
+        ];
         $client = new Client($params);
         $params = [
             'index'=>'noindexname',

--- a/test/Manticoresearch/Endpoints/Pq/DocTest.php
+++ b/test/Manticoresearch/Endpoints/Pq/DocTest.php
@@ -13,7 +13,6 @@ class DocTest extends \PHPUnit\Framework\TestCase
     {
         $client = new Client();
         $params = [
-
             'body' => [
                 'query' => ['match'=>['subject'=>'test']],
                 'tags' => ['test1','test2']

--- a/test/Manticoresearch/Endpoints/SearchTest.php
+++ b/test/Manticoresearch/Endpoints/SearchTest.php
@@ -8,7 +8,11 @@ class SearchTest  extends \PHPUnit\Framework\TestCase
 {
     public function testEmptyBody()
     {
-        $params = ['host' => $_SERVER['MS_HOST'], 'port' => $_SERVER['MS_PORT']];
+        $params = [
+            'host' => $_SERVER['MS_HOST'],
+            'port' => $_SERVER['MS_PORT'],
+            'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
+        ];
         $client = new Client($params);
         $this->expectException(\Manticoresearch\Exceptions\ResponseException::class);
         $client->search(['body'=>'']);
@@ -16,19 +20,25 @@ class SearchTest  extends \PHPUnit\Framework\TestCase
 
     public function testNoArrayParams()
     {
-        $params = ['host' => $_SERVER['MS_HOST'], 'port' => $_SERVER['MS_PORT']];
-        $client = new Client($params);
+        $params = [
+            'host' => $_SERVER['MS_HOST'],
+            'port' => $_SERVER['MS_PORT'],
+            'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
+        ];        $client = new Client($params);
         $this->expectException(TypeError::class);
         $client->search('this is not a json');
     }
     public function testMissingIndex()
     {
-        $params = ['host' => $_SERVER['MS_HOST'], 'port' => $_SERVER['MS_PORT']];
+        $params = [
+            'host' => $_SERVER['MS_HOST'],
+            'port' => $_SERVER['MS_PORT'],
+            'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
+        ];
         $client = new Client($params);
         $this->expectException(\Manticoresearch\Exceptions\ResponseException::class);
         $client->search( [
             'body' => [
-
                 'query' => [
                     'match_phrase' => [
                         'title' => 'find me',
@@ -36,7 +46,6 @@ class SearchTest  extends \PHPUnit\Framework\TestCase
                 ]
             ]
         ]);
-
     }
 
     public function testPath()

--- a/test/Manticoresearch/Helper/PopulateHelperTest.php
+++ b/test/Manticoresearch/Helper/PopulateHelperTest.php
@@ -11,7 +11,9 @@ class PopulateHelperTest extends \PHPUnit\Framework\TestCase
 
     public function getClient()
     {
-        $params = ['host' => $_SERVER['MS_HOST'], 'port' => 9308];
+        $params = ['host' => $_SERVER['MS_HOST'], 'port' => 9308,
+            'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
+        ];
         $this->client = new Client($params);
         return $this->client;
     }
@@ -84,7 +86,7 @@ class PopulateHelperTest extends \PHPUnit\Framework\TestCase
     {
         return $this->client->nodes()->status();
     }
-    
+
     public function testDummy()
     {
        $a = 1;

--- a/test/Manticoresearch/SearchTest.php
+++ b/test/Manticoresearch/SearchTest.php
@@ -36,7 +36,11 @@ class SearchTest extends TestCase
 
     protected static function indexDocuments(): Search
     {
-        $params = ['host' => $_SERVER['MS_HOST'], 'port' => $_SERVER['MS_PORT']];
+        $params = [
+            'host' => $_SERVER['MS_HOST'],
+            'port' => $_SERVER['MS_PORT'],
+            'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
+        ];
 
         $client = new Client($params);
         $client->indices()->drop(['index' => 'movies','body'=>['silent'=>true]]);
@@ -147,7 +151,9 @@ class SearchTest extends TestCase
 
     public function testConstructor()
     {
-        $params = ['host' => $_SERVER['MS_HOST'], 'port' => $_SERVER['MS_PORT']];
+        $params = ['host' => $_SERVER['MS_HOST'], 'port' => $_SERVER['MS_PORT'],
+            'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
+        ];
         $client = new Client($params);
         $searchObj = new Search($client);
         $this->assertEquals($client, $searchObj->getClient());


### PR DESCRIPTION
hi Adrian,

There were a couple of issues here:

1) Various composer packages were missing meaning that discovery was failing
2) The `$headers` variable is key --> value

I've changed the transport in `SearchTest` only to provide more coverage.  This is when I found the bugs now fixed

Cheers

Gordon