### PR TITLE
FIX: PhpHttp transport now works, test suite passing in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
       env: PHPUNIT_TEST=1
     - php: 7.4
       env: PHPUNIT_TEST=1
+    - php: 7.4
+      env: PHPUNIT_TEST=1 TRANSPORT=PhpHttp
 
 services:
   -  docker
@@ -35,6 +37,7 @@ install:
   - composer install --prefer-dist
 
 script:
+  - if [[ $TRANSPORT ]]; then composer require php-http/discovery php-http/curl-client guzzlehttp/psr7 php-http/message http-interop/http-factory-guzzle; fi
   - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit -d memory_limit=4G  test/; fi
   - if [[ $PHPUNIT_COVERAGE_TEST ]]; then phpdbg -qrr vendor/bin/phpunit -d memory_limit=4G --coverage-clover=coverage.xml   test/   ; fi
   - if [[ $PHPCS_TEST ]]; then vendor/bin/phpcs --config-set ignore_errors_on_exit 1 && vendor/bin/phpcs --config-set ignore_warnings_on_exit 1 && vendor/bin/phpcs src/ test/ ; fi

--- a/test/Manticoresearch/ClientTest.php
+++ b/test/Manticoresearch/ClientTest.php
@@ -39,7 +39,11 @@ class ClientTest extends TestCase
 
     public function testCreationWithConnection()
     {
-        $params = ['host' => $_SERVER['MS_HOST'], 'port' => $_SERVER['MS_PORT']];
+        $params = [
+            'host' => $_SERVER['MS_HOST'],
+            'port' => $_SERVER['MS_PORT'],
+            'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
+        ];
         $connection = new Connection($params);
         $params = ['connections' => $connection];
         $client = new Client($params);

--- a/test/Manticoresearch/Connection/Strategy/RandomTest.php
+++ b/test/Manticoresearch/Connection/Strategy/RandomTest.php
@@ -13,15 +13,16 @@ class RandomTest extends TestCase
         srand(1000);
 
         $client = new Client(["connectionStrategy"  =>"Random"]);
-
         $client->setHosts([
             [
                 'host' => $_SERVER['MS_HOST'],
-                'port' => (int)($_SERVER['MS_PORT'])
+                'port' => (int)($_SERVER['MS_PORT']),
+                'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
             ],
             [
                 'host' => $_SERVER['MS_HOST'],
-                'port' => 9309
+                'port' => 9309,
+                'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
             ],
 
         ]);

--- a/test/Manticoresearch/Connection/Strategy/RoundRobinTest.php
+++ b/test/Manticoresearch/Connection/Strategy/RoundRobinTest.php
@@ -14,13 +14,14 @@ class RoundRobinTest extends TestCase
         $client->setHosts([
             [
                 'host' => $_SERVER['MS_HOST'],
-                'port' => $_SERVER['MS_PORT']
+                'port' => $_SERVER['MS_PORT'],
+                'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
             ],
             [
                 'host' => $_SERVER['MS_HOST'],
-                'port' => 9309
+                'port' => 9309,
+                'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
             ],
-
         ]);
 
         $connection = $client->getConnectionPool()->getConnection();

--- a/test/Manticoresearch/Connection/Strategy/StaticRoundRobinTest.php
+++ b/test/Manticoresearch/Connection/Strategy/StaticRoundRobinTest.php
@@ -14,13 +14,14 @@ class StaticRoundRobinTest extends TestCase
         $client->setHosts([
             [
                 'host' => $_SERVER['MS_HOST'],
-                'port' => $_SERVER['MS_PORT']
+                'port' => $_SERVER['MS_PORT'],
+                'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
             ],
             [
                 'host' => $_SERVER['MS_HOST'],
-                'port' => $_SERVER['MS_PORT']
+                'port' => $_SERVER['MS_PORT'],
+                'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
             ],
-
         ]);
 
         $connection = $client->getConnectionPool()->getConnection();

--- a/test/Manticoresearch/Endpoints/BulkTest.php
+++ b/test/Manticoresearch/Endpoints/BulkTest.php
@@ -9,7 +9,12 @@ class BulkTest extends \PHPUnit\Framework\TestCase
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
-        $params = ['host' => $_SERVER['MS_HOST'], 'port' => $_SERVER['MS_PORT']];
+        $params = [
+            'host' => $_SERVER['MS_HOST'],
+            'port' => $_SERVER['MS_PORT'],
+            'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
+        ];
+
         static::$client = new Client($params);
         $params = [
             'index' => 'bulktest',

--- a/test/Manticoresearch/Endpoints/HelpersTest.php
+++ b/test/Manticoresearch/Endpoints/HelpersTest.php
@@ -8,7 +8,11 @@ class HelpersTest  extends \PHPUnit\Framework\TestCase
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
-        $params = ['host' => $_SERVER['MS_HOST'], 'port' => $_SERVER['MS_PORT']];
+        $params = [
+            'host' => $_SERVER['MS_HOST'],
+            'port' => $_SERVER['MS_PORT'],
+            'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
+        ];
         static::$client = new Client($params);
         $params = [
             'index' => 'products',

--- a/test/Manticoresearch/Endpoints/Indices/CreateTest.php
+++ b/test/Manticoresearch/Endpoints/Indices/CreateTest.php
@@ -10,7 +10,11 @@ class CreateTest  extends \PHPUnit\Framework\TestCase
 {
     public function testCreateTableWithOptions()
     {
-        $params = ['host' => $_SERVER['MS_HOST'], 'port' => $_SERVER['MS_PORT']];
+        $params = [
+            'host' => $_SERVER['MS_HOST'],
+            'port' => $_SERVER['MS_PORT'],
+            'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
+        ];
         $client = new Client($params);
         $params = [
             'index' => 'products',
@@ -78,7 +82,11 @@ class CreateTest  extends \PHPUnit\Framework\TestCase
 
     public function testNoIndexDrop()
     {
-        $params = ['host' => $_SERVER['MS_HOST'], 'port' => $_SERVER['MS_PORT']];
+        $params = [
+            'host' => $_SERVER['MS_HOST'],
+            'port' => $_SERVER['MS_PORT'],
+            'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
+        ];
         $client = new Client($params);
         $params = [
             'index'=>'noindexname',

--- a/test/Manticoresearch/Endpoints/SearchTest.php
+++ b/test/Manticoresearch/Endpoints/SearchTest.php
@@ -8,7 +8,11 @@ class SearchTest  extends \PHPUnit\Framework\TestCase
 {
     public function testEmptyBody()
     {
-        $params = ['host' => $_SERVER['MS_HOST'], 'port' => $_SERVER['MS_PORT']];
+        $params = [
+            'host' => $_SERVER['MS_HOST'],
+            'port' => $_SERVER['MS_PORT'],
+            'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
+        ];
         $client = new Client($params);
         $this->expectException(\Manticoresearch\Exceptions\ResponseException::class);
         $client->search(['body'=>'']);
@@ -16,14 +20,22 @@ class SearchTest  extends \PHPUnit\Framework\TestCase
 
     public function testNoArrayParams()
     {
-        $params = ['host' => $_SERVER['MS_HOST'], 'port' => $_SERVER['MS_PORT']];
+        $params = [
+            'host' => $_SERVER['MS_HOST'],
+            'port' => $_SERVER['MS_PORT'],
+            'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
+        ];
         $client = new Client($params);
         $this->expectException(TypeError::class);
         $client->search('this is not a json');
     }
     public function testMissingIndex()
     {
-        $params = ['host' => $_SERVER['MS_HOST'], 'port' => $_SERVER['MS_PORT']];
+        $params = [
+            'host' => $_SERVER['MS_HOST'],
+            'port' => $_SERVER['MS_PORT'],
+            'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
+        ];
         $client = new Client($params);
         $this->expectException(\Manticoresearch\Exceptions\ResponseException::class);
         $client->search( [

--- a/test/Manticoresearch/Helper/PopulateHelperTest.php
+++ b/test/Manticoresearch/Helper/PopulateHelperTest.php
@@ -11,7 +11,11 @@ class PopulateHelperTest extends \PHPUnit\Framework\TestCase
 
     public function getClient()
     {
-        $params = ['host' => $_SERVER['MS_HOST'], 'port' => 9308];
+        $params = [
+            'host' => $_SERVER['MS_HOST'],
+            'port' => $_SERVER['MS_PORT'],
+            'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
+        ];
         $this->client = new Client($params);
         return $this->client;
     }
@@ -84,7 +88,7 @@ class PopulateHelperTest extends \PHPUnit\Framework\TestCase
     {
         return $this->client->nodes()->status();
     }
-    
+
     public function testDummy()
     {
        $a = 1;

--- a/test/Manticoresearch/IndexTest.php
+++ b/test/Manticoresearch/IndexTest.php
@@ -18,7 +18,11 @@ class IndexTest extends TestCase
 
     protected function _getIndex($keywords = false): Index
     {
-        $params = ['host' => $_SERVER['MS_HOST'],'port'=> $_SERVER['MS_PORT']];
+        $params = [
+            'host' => $_SERVER['MS_HOST'],
+            'port' => $_SERVER['MS_PORT'],
+            'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
+        ];
         $index = new Index(new Client($params));
         $index->setName('testindex');
         $index->drop(true);

--- a/test/Manticoresearch/SearchTest.php
+++ b/test/Manticoresearch/SearchTest.php
@@ -36,8 +36,11 @@ class SearchTest extends TestCase
 
     protected static function indexDocuments(): Search
     {
-        $params = ['host' => $_SERVER['MS_HOST'], 'port' => $_SERVER['MS_PORT']];
-
+        $params = [
+            'host' => $_SERVER['MS_HOST'],
+            'port' => $_SERVER['MS_PORT'],
+            'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
+        ];
         $client = new Client($params);
         $client->indices()->drop(['index' => 'movies','body'=>['silent'=>true]]);
         $index = [
@@ -147,7 +150,11 @@ class SearchTest extends TestCase
 
     public function testConstructor()
     {
-        $params = ['host' => $_SERVER['MS_HOST'], 'port' => $_SERVER['MS_PORT']];
+        $params = [
+            'host' => $_SERVER['MS_HOST'],
+            'port' => $_SERVER['MS_PORT'],
+            'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
+        ];
         $client = new Client($params);
         $searchObj = new Search($client);
         $this->assertEquals($client, $searchObj->getClient());


### PR DESCRIPTION
hi Adrian,

I've had another stab at this and have the tests passing for the alternative Http transport.

Fixes (in PhpHttp) to make transport consistent with Http
1) Header for Content-Type  now key => value
2) Response needs parsed by the SqlToArray class
3) A ResponseException needs thrown after an error occurs

Wherever MS_HOST and MS_PORT were used in the testing code, I added an extra parameter `TRANSPORT` thus:

```
$params = [
            'host' => $_SERVER['MS_HOST'],
            'port' => $_SERVER['MS_PORT'],
            'transport' => empty($_SERVER['TRANSPORT']) ? 'Http' : $_SERVER['TRANSPORT']
        ];
```
This means that if TRANSPORT is not provided, it defaults to the original default (and thus the other tests pass as before).  However adding this to Travis in the matrix as below means that the test suite is run once with the alternative transport

```
matrix:
  include:
    - php: 7.1
      env: PHPUNIT_TEST=1
    - php: 7.2
      env: PHPUNIT_COVERAGE_TEST=1
    - php: 7.2
      env: PHPCS_TEST=1
    - php: 7.3
      env: PHPUNIT_TEST=1
    - php: 7.4
      env: PHPUNIT_TEST=1
    - php: 7.4
      env: PHPUNIT_TEST=1 TRANSPORT=PhpHttp
```

In the script section the extra necessary composer packages are installed when using PhpTransport

```
script:
  - if [[ $TRANSPORT ]]; then composer require php-http/discovery php-http/curl-client guzzlehttp/psr7 php-http/message http-interop/http-factory-guzzle; fi
```

Cheers

Gordon