### PR TITLE
FIX: Documentation was missing a quote for the set example

### DIFF
--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -110,7 +110,7 @@ Set a Galera option to the cluster.
              'body' => [
                  'variable'=> [
                     'name' => 'pc.bootstrap',
-                    'value=>'`'
+                    'value'=>'`'
                  ]
                  
              ]


### PR DESCRIPTION
The `value` key in the `$params` example in the documentation was missing a trailing quote.