### PR TITLE
Additional "index" method added to Client class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea/
 composer.lock
 vendor/

--- a/README.md
+++ b/README.md
@@ -60,12 +60,22 @@ composer require manticoresoftware/manticoresearch-php
 ### Initiate the index:
 
 ```php
-   require_once __DIR__ . '/vendor/autoload.php';
+require_once __DIR__ . '/vendor/autoload.php';
 
-   $config = ['host'=>'127.0.0.1','port'=>9308];
-   $client = new \Manticoresearch\Client($config);
-   $index = new \Manticoresearch\Index($client);
-   $index->setName('movies'); 
+$config = ['host'=>'127.0.0.1','port'=>9308];
+$client = new \Manticoresearch\Client($config);
+$index = new \Manticoresearch\Index($client);
+$index->setName('movies'); 
+```
+
+or alternative way
+
+```php
+require_once __DIR__ . '/vendor/autoload.php';
+
+$config = ['host'=>'127.0.0.1','port'=>9308];
+$client = new \Manticoresearch\Client($config);
+$index = $client->index('movies');
 ```
 
 ### Create index:

--- a/src/Manticoresearch/Client.php
+++ b/src/Manticoresearch/Client.php
@@ -273,6 +273,18 @@ class Client
     }
 
     /**
+     * Return Index object
+     *
+     * @param string|null $name Name of index
+     *
+     * @return \Manticoresearch\Index
+     */
+    public function index(string $name = null): Index
+    {
+        return new Index($this, $name);
+    }
+
+    /**
      * Endpoint: bulk
      * @param array $params
      * @return array

--- a/test/Manticoresearch/ClientTest.php
+++ b/test/Manticoresearch/ClientTest.php
@@ -36,6 +36,23 @@ class ClientTest extends TestCase
         $this->assertInstanceOf('Manticoresearch\Cluster', $client->cluster());
     }
 
+    public function testIndex(): void
+    {
+        $client = new Client();
+        $index = $client->index();
+
+        $this->assertInstanceOf('Manticoresearch\Index', $index);
+    }
+
+    public function testIndexName(): void
+    {
+        $client = new Client();
+        $index = $client->index('video');
+
+        $this->assertInstanceOf('Manticoresearch\Index', $index);
+        $this->assertEquals('video', $index->getName());
+    }
+
     public function testCreationWithConnection()
     {
         $params = [


### PR DESCRIPTION
Hello @adriannuta! Here is a couple updates about which we talked some time ago:

* To Client class added `->index(string $name = null)` method
* Additional tests of index method added to ClientTest
* Note about index method added to readme
* To .gitignore added .idea string