### PR TITLE
New filters and getDocumentByIds

### DIFF
--- a/src/Manticoresearch/Index.php
+++ b/src/Manticoresearch/Index.php
@@ -50,6 +50,22 @@ class Index
         return $result->valid() ? $result->current() : null;
     }
 
+    public function getDocumentByIds($ids)
+    {
+        if (!is_array($ids)) {
+            $ids = [$ids];
+        }
+        $params = [
+            'body' => [
+                'index' => $this->index,
+                'query' => [
+                    'in' => ['id' => $ids]
+                ]
+            ]
+        ];
+        return new ResultSet($this->client->search($params, true));
+    }
+
     public function addDocument($data, $id = 0)
     {
         if (is_object($data)) {

--- a/src/Manticoresearch/Search.php
+++ b/src/Manticoresearch/Search.php
@@ -22,6 +22,10 @@ use Manticoresearch\Query\ScriptFields;
  */
 class Search
 {
+    const FILTER_AND = "AND";
+    const FILTER_OR = "OR";
+    const FILTER_NOT = "NOT";
+
     /**
      * @var Client
      */
@@ -171,7 +175,7 @@ class Search
         return $object;
     }
 
-    public function filter($attr, $op = null, $values = null, $boolean = "AND"): self
+    public function filter($attr, $op = null, $values = null, $boolean = self::FILTER_AND): self
     {
         if (!is_object($attr)) {
             if (is_null($values)) {
@@ -190,11 +194,11 @@ class Search
             }
         }
 
-        if ($boolean === "AND") {
+        if ($boolean === self::FILTER_AND) {
             $this->query->must($attr);
-        } else if($boolean === "OR") {
+        } else if($boolean === self::FILTER_OR) {
             $this->query->should($attr);
-        } else if($boolean === "NOT") {
+        } else if($boolean === self::FILTER_NOT) {
             $this->query->mustNot($attr);
         }
 
@@ -203,12 +207,12 @@ class Search
 
     public function orFilter($attr, $op = null, $values = null): self
     {
-        return $this->filter($attr, $op, $values, 'OR');
+        return $this->filter($attr, $op, $values, self::FILTER_OR);
     }
 
     public function notFilter($attr, $op = null, $values = null): self
     {
-        return $this->filter($attr, $op, $values, 'NOT');
+        return $this->filter($attr, $op, $values, self::FILTER_NOT);
     }
 
     public function offset($offset): self

--- a/src/Manticoresearch/Search.php
+++ b/src/Manticoresearch/Search.php
@@ -184,6 +184,10 @@ class Search
             }
 
             $attr = $this->getAttrObject($attr, $op, $values);
+
+            if (!$attr) {
+                return $this;
+            }
         }
 
         if ($boolean === "AND") {


### PR DESCRIPTION
Hello. Added more intuitive features and made a general filter, since previously the filters (orFilter, notFilter and filter) were similar in code

```
filter('field', 'equals', 1) <=> filter('field', '=', 1) <=> filter('field', 1)
filter('field', 'gte', 1) <=> filter('field', '>=' ,1)
filter('field', 'gt', 1) <=> filter('field', '>' ,1)
filter('field', 'lte', 1) <=> filter('field', '<=' ,1)
filter('field', 'lt', 1) <=> filter('field', '<' ,1)

orFilter('field', 'equals', 1) <=> orFilter('field', '=', 1) <=> orFilter('field', 1)
orFilter('field', 'gte', 1) <=> orFilter('field', '>=' ,1)
...

notFilter('field','equals',1) <=> notFilter('field', '=', 1) <=> notFilter('field', 1)
notFilter('field','gte',1) <=> notFilter('field', '>=' ,1)
...
```

And `getDocumentByIds` it is easy to check multiple IDs at once