### PR TITLE
Support http OPTIONS parameters

### DIFF
--- a/docs/searchclass.md
+++ b/docs/searchclass.md
@@ -194,7 +194,21 @@ Parameters:
  * a limit on the number of facet values to return
  
 The facets will be returned in the result set and can be retrieved with [ResultSet:getFacets()](searchresults.md#resultset-object).
-   
+
+### option()
+
+Pass options to the search query.
+```php
+    $search->option('cutoff', 1);
+    $search->option('retry_count', 3);
+    $search->option('field_weights', ['title' => 100, 'description' => 200]);
+
+    // chain options
+    $search->option('ranker', 'sph04')->option('retry_delay', 5);
+
+    // unset options by passing null
+    $search->option('ranker', null);
+```
 
 ### profile()
 

--- a/src/Manticoresearch/Search.php
+++ b/src/Manticoresearch/Search.php
@@ -272,6 +272,12 @@ class Search
         return $this;
     }
 
+    public function option($name, $value): self
+    {
+        $this->params['options'][$name] = $value;
+        return $this;
+    }
+
     public function profile(): self
     {
         $this->params['profile'] = true;

--- a/src/Manticoresearch/Search.php
+++ b/src/Manticoresearch/Search.php
@@ -274,7 +274,12 @@ class Search
 
     public function option($name, $value): self
     {
-        $this->params['options'][$name] = $value;
+        if (is_null($value)) {
+            unset($this->params['options'][$name]);
+        } else {
+            $this->params['options'][$name] = $value;
+        }
+
         return $this;
     }
 

--- a/test/Manticoresearch/SearchTest.php
+++ b/test/Manticoresearch/SearchTest.php
@@ -711,6 +711,15 @@ class SearchTest extends TestCase
         $this->assertCount(2, $results->current()->getHighlight());
     }
 
+    public function testBodyHasOptions()
+    {
+        $body = self::$search
+            ->option('retry_count', 3)->option('field_weights', ['title' => 2, 'plot' => 1])
+            ->compile();
+
+        $this->assertEquals(['retry_count' => 3, 'field_weights' => ['title' => 2, 'plot' => 1]], $body['options']);
+    }
+
     public function testResultHitGetData()
     {
         $resultHit = $this->getFirstResultHit();

--- a/test/Manticoresearch/SearchTest.php
+++ b/test/Manticoresearch/SearchTest.php
@@ -720,6 +720,20 @@ class SearchTest extends TestCase
         $this->assertEquals(['retry_count' => 3, 'field_weights' => ['title' => 2, 'plot' => 1]], $body['options']);
     }
 
+    public function testUnsetOption()
+    {
+        self::$search->option('retry_count', 3)->option('retry_delay', 4);
+        self::$search->option('retry_count', null);
+        $body = self::$search->compile();
+
+        $this->assertEquals(['retry_delay' => 4], $body['options']);
+    }
+
+    public function testCutoffOption()
+    {
+        $this->assertCount(2, self::$search->search('')->option('cutoff', 2)->get());
+    }
+
     public function testResultHitGetData()
     {
         $resultHit = $this->getFirstResultHit();


### PR DESCRIPTION
This PR adds method `option` which enables us to pass `OPTIONS` parameters over http.