### PR TITLE
Add trackScores method

### DIFF
--- a/docs/searchclass.md
+++ b/docs/searchclass.md
@@ -210,6 +210,15 @@ Pass options to the search query.
     $search->option('ranker', null);
 ```
 
+### trackScores()
+You can enable weight calculation by setting the `track_scores` option to `true`.
+
+```php
+    $search->trackScores(true); // enable weight calculation
+    $search->trackScores(false); // disable weight calculation
+    $search->trackScores(null); // unset track_scores option
+```
+
 ### profile()
 
 If included, result set will provide query profiling.

--- a/src/Manticoresearch/Search.php
+++ b/src/Manticoresearch/Search.php
@@ -64,6 +64,17 @@ class Search
         return $this;
     }
 
+    public function trackScores($trackScores): self
+    {
+        if (is_null($trackScores)) {
+            unset($this->params['track_scores']);
+        } else {
+            $this->params['track_scores'] = (bool)$trackScores;
+        }
+
+        return $this;
+    }
+
     /**
      * @param string $queryString
      * @return $this

--- a/test/Manticoresearch/SearchTest.php
+++ b/test/Manticoresearch/SearchTest.php
@@ -746,6 +746,35 @@ class SearchTest extends TestCase
         $this->assertCount(2, self::$search->search('')->option('cutoff', 2)->get());
     }
 
+    public function testTrackScoresCompiles()
+    {
+        $body = self::$search->trackScores(true)->compile();
+        $this->assertTrue($body['track_scores']);
+
+        $body = self::$search->trackScores(false)->compile();
+        $this->assertFalse($body['track_scores']);
+
+        $body = self::$search->trackScores(null)->compile();
+        $this->assertArrayNotHasKey('track_scores', $body);
+    }
+
+    public function testTrackScores()
+    {
+        // when there are match and sort, but there is no track_scores, the score is equal to 1
+        $result = self::$search->search('space')->sort('year', 'desc')->get();
+        $this->assertCount(2, $result);
+        foreach ($result as $resultHit) {
+            $this->assertEquals(1, $resultHit->getScore());
+        }
+
+        // when there are match, sort and track_scores, the score is greater than 1
+        $result = self::$search->search('space')->trackScores(true)->sort('year', 'desc')->get();
+        $this->assertCount(2, $result);
+        foreach ($result as $resultHit) {
+            $this->assertGreaterThan(1, $resultHit->getScore());
+        }
+    }
+
     public function testResultHitGetData()
     {
         $resultHit = $this->getFirstResultHit();


### PR DESCRIPTION
This PR adds a new method that enables us to pass the `track_scores` parameter.