### PR TITLE
Handling bad UTF8 characters

### DIFF
--- a/docs/searchclass.md
+++ b/docs/searchclass.md
@@ -219,6 +219,15 @@ You can enable weight calculation by setting the `track_scores` option to `true`
     $search->trackScores(null); // unset track_scores option
 ```
 
+### stripBadUtf8()
+You can enable removal of bad utf8 characters from the results by setting the `strip_bad_utf8` option to `true`.
+
+```php
+    $search->stripBadUtf8(true); // enable removal of bad utf8 characters
+    $search->stripBadUtf8(false); // disable removal of bad utf8 characters
+    $search->stripBadUtf8(null); // unset strip_bad_utf8 option
+```
+
 ### profile()
 
 If included, result set will provide query profiling.

--- a/src/Manticoresearch/Response.php
+++ b/src/Manticoresearch/Response.php
@@ -73,8 +73,9 @@ class Response
             if (json_last_error() !== JSON_ERROR_NONE) {
                 if (json_last_error() === JSON_ERROR_UTF8) {
                     $this->response = json_decode(preg_replace('/[\x00-\x1F\x80-\xFF]/', '', $this->string), true);
-                } else
+                } else {
                     throw new RuntimeException('fatal error while trying to decode JSON response');
+                }
             }
 
             if (empty($this->response)) {

--- a/src/Manticoresearch/Response.php
+++ b/src/Manticoresearch/Response.php
@@ -69,9 +69,12 @@ class Response
     public function getResponse()
     {
         if (null === $this->response) {
-            $this->response = json_decode(preg_replace('/[\x00-\x1F\x80-\xFF]/', '', $this->string), true);
+            $this->response = json_decode($this->string, true);
             if (json_last_error() !== JSON_ERROR_NONE) {
-                throw new RuntimeException('fatal error while trying to decode JSON response');
+                if (json_last_error() === JSON_ERROR_UTF8) {
+                    $this->response = json_decode(preg_replace('/[\x00-\x1F\x80-\xFF]/', '', $this->string), true);
+                } else
+                    throw new RuntimeException('fatal error while trying to decode JSON response');
             }
 
             if (empty($this->response)) {

--- a/src/Manticoresearch/Response.php
+++ b/src/Manticoresearch/Response.php
@@ -71,7 +71,7 @@ class Response
         if (null === $this->response) {
             $this->response = json_decode($this->string, true);
             if (json_last_error() !== JSON_ERROR_NONE) {
-                if (json_last_error() === JSON_ERROR_UTF8) {
+                if (json_last_error() === JSON_ERROR_UTF8 && $this->stripBadUtf8()) {
                     $this->response = json_decode(preg_replace('/[\x00-\x1F\x80-\xFF]/', '', $this->string), true);
                 } else {
                     throw new RuntimeException('fatal error while trying to decode JSON response');
@@ -83,6 +83,14 @@ class Response
             }
         }
         return $this->response;
+    }
+    
+    /**
+     * check if strip_bad_utf8 as been set to true
+     * @return boolean
+     */
+    private function stripBadUtf8() {
+        return !empty($this->transportInfo['body']) && !empty($this->transportInfo['body']['strip_bad_utf8']);
     }
 
     /*

--- a/src/Manticoresearch/Response.php
+++ b/src/Manticoresearch/Response.php
@@ -89,7 +89,7 @@ class Response
      * check if strip_bad_utf8 as been set to true
      * @return boolean
      */
-    private function stripBadUtf8() 
+    private function stripBadUtf8()
     {
         return !empty($this->transportInfo['body']) && !empty($this->transportInfo['body']['strip_bad_utf8']);
     }

--- a/src/Manticoresearch/Response.php
+++ b/src/Manticoresearch/Response.php
@@ -89,7 +89,8 @@ class Response
      * check if strip_bad_utf8 as been set to true
      * @return boolean
      */
-    private function stripBadUtf8() {
+    private function stripBadUtf8() 
+    {
         return !empty($this->transportInfo['body']) && !empty($this->transportInfo['body']['strip_bad_utf8']);
     }
 

--- a/src/Manticoresearch/Response.php
+++ b/src/Manticoresearch/Response.php
@@ -69,8 +69,7 @@ class Response
     public function getResponse()
     {
         if (null === $this->response) {
-            $this->response = json_decode($this->string, true);
-
+            $this->response = json_decode(preg_replace('/[\x00-\x1F\x80-\xFF]/', '', $this->string), true);
             if (json_last_error() !== JSON_ERROR_NONE) {
                 throw new RuntimeException('fatal error while trying to decode JSON response');
             }

--- a/src/Manticoresearch/Search.php
+++ b/src/Manticoresearch/Search.php
@@ -75,6 +75,17 @@ class Search
         return $this;
     }
 
+    public function stripBadUtf8($stripBadUtf8): self
+    {
+        if (is_null($stripBadUtf8)) {
+            unset($this->params['strip_bad_utf8']);
+        } else {
+            $this->params['strip_bad_utf8'] = (bool)$stripBadUtf8;
+        }
+        
+        return $this;
+    }
+    
     /**
      * @param string $queryString
      * @return $this

--- a/test/Manticoresearch/SearchTest.php
+++ b/test/Manticoresearch/SearchTest.php
@@ -774,6 +774,18 @@ class SearchTest extends TestCase
             $this->assertGreaterThan(1, $resultHit->getScore());
         }
     }
+    
+    public function testStripBadUtf8Compiles()
+    {
+        $body = self::$search->stripBadUtf8(true)->compile();
+        $this->assertTrue($body['strip_bad_utf8']);
+        
+        $body = self::$search->stripBadUtf8(false)->compile();
+        $this->assertFalse($body['strip_bad_utf8']);
+        
+        $body = self::$search->stripBadUtf8(null)->compile();
+        $this->assertArrayNotHasKey('strip_bad_utf8', $body);
+    }
 
     public function testResultHitGetData()
     {


### PR DESCRIPTION
If source document contains malformed UTF-8 characters, possibly incorrectly encoded, this characters are stripped instead of throwing an exception. 
Throwing an exception may be too severe, maybe it's better to provide the caller with usable data instead of providing no results at all


