### PR TITLE
fixes error when creating a distributed index

### DIFF
--- a/docs/indexclass.md
+++ b/docs/indexclass.md
@@ -66,8 +66,9 @@ If a setting can have multiple values, an array of values will be used, like:
 ```php
  $index->setName('mynewindex');
  $index->create([],
-    ['type' => 'distributed'],
-    ['local' => [
+    [
+        'type' => 'distributed',
+        'local' => [
             'local_index_1',
             'local_index_2',
         ]

--- a/src/Manticoresearch/Endpoints/Indices/Create.php
+++ b/src/Manticoresearch/Endpoints/Indices/Create.php
@@ -34,7 +34,6 @@ class Create extends EmulateBySql
             $options = "";
             if (isset($params['settings'])) {
                 foreach ($params['settings'] as $name => $value) {
-                    $options.=" ".$name." = '".$value."'";
                     if (is_array($value)) {
                         foreach ($value as $v) {
                             $options.=" ".$name." = '".$v."'";


### PR DESCRIPTION
When creating a distributed index like this
```
$index = new \Manticoresearch\Index($client);
$index->setName('test_distributed_index');
$index->create([], [
    'type' => 'distributed',
    'local' => [
        'local_1',
        'local_2',
    ],
]);
```
i was receiving an error 
```
 Array to string conversion
  at vendor/manticoresoftware/manticoresearch-php/src/Manticoresearch/Endpoints/Indices/Create.php:37

```

Also fixed documentation.