### PR TITLE
Log request url and request payload on response error

### DIFF
--- a/src/Manticoresearch/Transport/Http.php
+++ b/src/Manticoresearch/Transport/Http.php
@@ -108,21 +108,22 @@ class Http extends \Manticoresearch\Transport implements TransportInterface
 
 
         $this->logger->debug('Request body:', [
-                'connection' => $connection->getConfig(),
-                'payload'=> $request->getBody()
-            ]);
-        $this->logger->info(
-            'Request:',
-            [
-                    'url' => $url,
-                    'status' => $status,
-                    'time' => $time
-                ]
-        );
+            'connection' => $connection->getConfig(),
+            'payload' => $request->getBody()
+        ]);
+        $this->logger->info('Request:', [
+            'url' => $url,
+            'status' => $status,
+            'time' => $time,
+        ]);
         $this->logger->debug('Response body:', [json_decode($responseString, true)]);
         //soft error
         if ($response->hasError()) {
-            $this->logger->error('Response error:', [$response->getError()]);
+            $this->logger->error('Response:', [
+                'url' => $url,
+                'error' => $response->getError(),
+                'payload' => $request->getBody(),
+            ]);
             throw new ResponseException($request, $response);
         }
         return $response;

--- a/src/Manticoresearch/Transport/PhpHttp.php
+++ b/src/Manticoresearch/Transport/PhpHttp.php
@@ -94,18 +94,19 @@ class PhpHttp extends Transport implements TransportInterface
             'connection' => $connection->getConfig(),
             'payload'=> $request->getBody()
         ]);
-        $this->logger->info(
-            'Request:',
-            [
-                 'url' => $url,
-                'status' => $status,
-                'time' => $time
-            ]
-        );
+        $this->logger->info('Request:', [
+            'url' => $url,
+            'status' => $status,
+            'time' => $time,
+        ]);
         $this->logger->debug('Response body:', $response->getResponse());
 
         if ($response->hasError()) {
-            $this->logger->error('Response error:', [$response->getError()]);
+            $this->logger->error('Response:', [
+                'url' => $url,
+                'error' => $response->getError(),
+                'payload' => $request->getBody(),
+            ]);
             throw new ResponseException($request, $response);
         }
         return $response;


### PR DESCRIPTION
This PR improves error logging by adding `url` and `payload` info to response logs.

It is useful when manticore runs on multiple nodes so we can know where an error occurred and what we have sent in a failed request.

If it is too much to accept both `url` and `payload`, you could accept at least `url`.