### PR TITLE
Remove unnecessary throw statement

### DIFF
--- a/src/Manticoresearch/Client.php
+++ b/src/Manticoresearch/Client.php
@@ -361,7 +361,10 @@ class Client
                 'request' => $request->toArray()
             ]);
             $this->initConnections();
-            throw $e;
+            
+            $connection = $this->connectionPool->getConnection();
+            $this->lastResponse = $connection->getTransportHandler($this->logger)->execute($request, $params);
+            
         } catch (ConnectionException $e) {
             $this->logger->warning('Manticore Search Request failed ' . $this->connectionPool->retries_attempts . ':', [
                 'exception' => $e->getMessage(),


### PR DESCRIPTION
This is related to the issue that I've opened: https://github.com/manticoresoftware/manticoresearch-php/issues/43

I've noticed that after reinitializing the connection, the throw statement is still there.
So the exception will still be fired, and won't be intercepted by the next catch statement (because it is a NoMoreNodes exception instance).

I've replaced this line by that block to make sure that a Response object will be returned : 

```php
        $connection = $this->connectionPool->getConnection();
        $this->lastResponse = $connection->getTransportHandler($this->logger)->execute($request, $params);
```