### PR TITLE
Fix PHP DocBlock of Search->search method

### DIFF
--- a/src/Manticoresearch/Search.php
+++ b/src/Manticoresearch/Search.php
@@ -87,7 +87,7 @@ class Search
     }
     
     /**
-     * @param string $queryString
+     * @param string|BoolQuery $queryString
      * @return $this
      */
     public function search($queryString): self


### PR DESCRIPTION
Q | A
-- | --
Branch? | master
Bug fix? | yes
New feature? | no
Deprecations? | no
Issue | https://github.com/manticoresoftware/manticoresearch-php/issues/128
License | MIT
Doc PR | -

# Description

Method `search()` of class `\Manticoresearch\Search` has incorrect PHP DocBlock: parameter `$queryString` has incomplete type `string`, because "this method accepts either a full-text match string or a BoolQuery object". 

This PR fix type of parameter `$queryString` in PHP DocBlock.
