### PR TITLE
ExceptionInterface does not extends Throwable

### DIFF
--- a/src/Manticoresearch/Exceptions/ExceptionInterface.php
+++ b/src/Manticoresearch/Exceptions/ExceptionInterface.php
@@ -3,10 +3,12 @@
 
 namespace Manticoresearch\Exceptions;
 
+use Throwable;
+
 /**
  * Interface ExceptionInterface
  * @package Manticoresearch\Exceptions
  */
-interface ExceptionInterface
+interface ExceptionInterface extends Throwable
 {
 }


### PR DESCRIPTION
Q | A
-- | --
Branch? | master
Bug fix? | yes
New feature? | no
Deprecations? | no
Issue | #130 
License | MIT
Doc PR | -

# Description

The interface `\Manticoresearch\Exceptions\ExceptionInterface` does not extends interface `\Throwable`, therefore it is not possible to use `ExceptionInterface to catch any Manticore Search exceptions.

This PR fix this issue.
