### PR TITLE
add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+/.github export-ignore
+/docker export-ignore
+/docs export-ignore
+/test export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/CHANGELOG.md export-ignore
+/CODE_OF_CONDUCT.md export-ignore
+/docker-compose.yml export-ignore
+/ruleset.xml export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,7 +4,6 @@
 /test export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
-/CHANGELOG.md export-ignore
 /CODE_OF_CONDUCT.md export-ignore
 /docker-compose.yml export-ignore
 /ruleset.xml export-ignore


### PR DESCRIPTION
.gitattributes allows to specify files which should be excluded from composer package. As a result, the size of the package will be smaller.