### PR TITLE
Explicitly specified the list of supported php versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "type": "library",
     "require": {
-        "php": ">=7.1",
+        "php": "^7.1|^8.0",
         "ext-json": "*",
         "psr/log": ">=1.1"
     },


### PR DESCRIPTION
Line `"php": ">=7.1"` is too wide in `composer.json`. It means that we support major versions of php that haven't even been released yet. But we can't guarantee that the library will work on php 9. It's better to explicitly specify the supported versions.

