### PR TITLE
Use the lowest supported php version in Dockerfile

### DIFF
--- a/docker/phpcli/7/Dockerfile
+++ b/docker/phpcli/7/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4.15-cli-buster
+FROM php:7.1-cli-buster
 
 RUN apt -y update && apt -y upgrade
 RUN apt -y install figlet git zip unzip


### PR DESCRIPTION
When we run `composer require` or `composer install` we need to be sure it works on the lowest supported php version.