### PR TITLE
Attach failed request to NoMoreNodesException

### DIFF
--- a/src/Manticoresearch/Client.php
+++ b/src/Manticoresearch/Client.php
@@ -347,6 +347,7 @@ class Client
 			$connection = $this->connectionPool->getConnection();
 			$this->lastResponse = $connection->getTransportHandler($this->logger)->execute($request, $params);
 		} catch (NoMoreNodesException $e) {
+			$e->setRequest($request);
 			$this->logger->error(
 				'Manticore Search Request out of retries:', [
 				'exception' => $e->getMessage(),

--- a/src/Manticoresearch/Exceptions/ConnectionException.php
+++ b/src/Manticoresearch/Exceptions/ConnectionException.php
@@ -32,4 +32,8 @@ class ConnectionException extends \RuntimeException implements ExceptionInterfac
 	public function getRequest() {
 		return $this->request;
 	}
+
+	public function setRequest(Request $request): void {
+		$this->request = $request;
+	}
 }


### PR DESCRIPTION
It is useful to retrieve a failed request in case of NoMoreNodesException.