### PR TITLE
(Security issue) Prevent raw output for timeouted requests

### DIFF
--- a/src/Manticoresearch/Transport/Http.php
+++ b/src/Manticoresearch/Transport/Http.php
@@ -52,6 +52,7 @@ class Http extends \Manticoresearch\Transport implements TransportInterface
 		curl_setopt($conn, CURLOPT_TIMEOUT, $connection->getTimeout());
 		curl_setopt($conn, CURLOPT_ENCODING, '');
 		curl_setopt($conn, CURLOPT_FORBID_REUSE, 0);
+		curl_setopt($conn, CURLOPT_RETURNTRANSFER, true);
 		$data = $request->getBody();
 		$method = $request->getMethod();
 		$headers = $connection->getHeaders();
@@ -91,9 +92,7 @@ class Http extends \Manticoresearch\Transport implements TransportInterface
 			}
 		}
 		$start = microtime(true);
-		ob_start();
-		curl_exec($conn);
-		$responseString = \ob_get_clean();
+		$responseString = curl_exec($conn);
 		$end = microtime(true);
 		$errorno = curl_errno($conn);
 		$status = curl_getinfo($conn, CURLINFO_HTTP_CODE);


### PR DESCRIPTION
Hello!
I found out that when a search request to the manticore search server reaches the curl maximum execution time, the response received up until the timeout gets **fully printed** directly to the user. This can be a serious security issue.

### Example:
```
$client = new Client([
  'host' => '127.0.0.1',
  'port' => 9308,
]);

$search = new Search($client);
$search->setTable('books');
$results = $search->match('a')->get();

echo 'Successfully got '.$results->getTotal().' results';
```
#### Output when timeouting
```
{"took":36210,"timed_out":false,"hits":{"total":48600,"total_relation":"eq","hits":[{"_id":123,"_score":8501,"_source":{"title":"hello world", ...
Fatal error: Maximum execution time of 30 seconds exceeded in ./vendor/manticoresoftware/manticoresearch-php/src/Manticoresearch/Transport/Http.php on line 97
```

Note that in the example code above, I never intended to print out the raw response, it does this on its own - that's a huge security issue!

In this PR, I fixed this bug by making a slight improvement to the `Http` transport class by disabling curl output and stop using the ob output buffer and instead directly using the returned string from curl.

**Specific code changes:**
* Added `CURLOPT_RETURNTRANSFER` to the cURL options to ensure the response is returned as a string instead of being output directly.
* Replaced the use of output buffering (`ob_start` and `ob_get_clean`) with direct assignment of the result from `curl_exec` to `$responseString`.

Please note my change is just a hotfix to disable any unintentional dangerous output. There may be a better way to fix this bug than this if you have a better understanding of the inner workings of this library. Especially considering that we _do_ get a successful response (even with `"timed_out":false`) and a fatal error gets thrown anyways.

_An_