### PR TITLE
Fix validation in replaceDocument

### DIFF
--- a/src/Manticoresearch/Table.php
+++ b/src/Manticoresearch/Table.php
@@ -210,12 +210,12 @@ class Table
 
 	public function replaceDocument($data, $id, $isPartialReplace = false) {
 		static::checkDocumentId($id);
-		static::checkDocument($data);
 		if (is_object($data)) {
 			$data = (array)$data;
 		} elseif (is_string($data)) {
 			$data = json_decode($data, true);
 		}
+		static::checkDocument($data);
 		$params = [
 			'body' => [
 				'doc' => $data,


### PR DESCRIPTION
Move document validation next to transformation from object or json to prevent error 
`Manticoresearch\Table::checkDocument(): Argument #1 ($data) must be of type array` when using document from object.